### PR TITLE
fix: only update jx-logging

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -20,5 +20,4 @@ spec:
             package: github.com/jenkins-x/jx-logging
             upgradePackages:
               include:
-                - "github.com/jenkins-x/*"
-                - "github.com/jenkins-x-plugins/*"
+                - "github.com/jenkins-x/jx-logging*"


### PR DESCRIPTION
Updating all other jx packages are likely to fail